### PR TITLE
Print multiline log messages (fixes #3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ arraydeque = "0.4.5"
 flexi_logger = "0.15.1"
 lazy_static = "1.4.0"
 log = "0.4.8"
+unicode-width = "0.1.7"
 
 [dev-dependencies]
 cursive = "0.15.0"

--- a/examples/no_indent.rs
+++ b/examples/no_indent.rs
@@ -1,7 +1,7 @@
 use cursive::view::Boxable;
 use cursive::views::Dialog;
 use cursive::{Cursive, CursiveExt, Vec2};
-use cursive_flexi_logger_view::FlexiLoggerView;
+use cursive_flexi_logger_view::{FlexiLoggerView, Indentable};
 
 use std::time::Duration;
 
@@ -22,7 +22,7 @@ fn main() {
         .expect("failed to initialize logger!");
 
     siv.add_layer(
-        Dialog::around(FlexiLoggerView::scrollable())
+        Dialog::around(FlexiLoggerView::scrollable().no_indent())
             .title("Flexi-Logger View")
             .button("Quit", |siv| siv.quit())
             .fixed_size(Vec2::new(72, 10)),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -41,6 +41,9 @@ fn main() {
         log::info!("An info log message");
         std::thread::sleep(Duration::from_secs(1));
 
+        log::debug!("Really detailed debug information\nfoo: 5\nbar: 42");
+        std::thread::sleep(Duration::from_secs(1));
+
         log::warn!("A warning log message");
         std::thread::sleep(Duration::from_secs(1));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,20 @@ impl Indentable for ScrollView<FlexiLoggerView> {
     }
 }
 
+impl Indentable for FlexiLoggerView {
+    /// Changes a `FlexiLoggerView` to not indent messages spanning multiple lines.
+    fn no_indent(mut self) -> Self {
+        self.indent = false;
+        self
+    }
+
+    /// Changes a `FlexiLoggerView` to indent messages spanning multiple lines.
+    fn indent(mut self) -> Self {
+        self.indent = true;
+        self
+    }
+}
+
 impl View for FlexiLoggerView {
     fn draw(&self, printer: &Printer<'_, '_>) {
         let logs = LOGS.lock().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ lazy_static::lazy_static! {
 ///         .start()
 ///         .expect("failed to initialize logger!");
 ///
-///     siv.add_layer(FlexiLoggerView{indent: true}); // add a plain flexi-logger view
+///     siv.add_layer(FlexiLoggerView::new()); // add a plain flexi-logger view
 ///
 ///     log::info!("test log message");
 ///     // siv.run();
@@ -183,6 +183,11 @@ impl FlexiLoggerView {
             .scroll_x(true)
             .scroll_y(true)
             .scroll_strategy(ScrollStrategy::StickToBottom)
+    }
+
+    /// Create a new `FlexiLoggerView`.
+    pub fn new() -> Self {
+        FlexiLoggerView { indent: true }
     }
 }
 


### PR DESCRIPTION
Implemented as suggested here: https://github.com/deinstapel/cursive-flexi-logger-view/pull/5#issuecomment-616413663 (issue #3)
Example:
```
DEBUG <src/main:46> first line
                    second line
```
Alternatively, it would now be trivial to implement (l.210: add `x = 0`) this format (which is consistent with FlexiLogger):
```
DEBUG <src/main:46> first line
second line
```