### PR TITLE
Sort of format for CursiveLogWriter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.5.0"
 [dependencies]
 cursive_core = "0.3"
 arraydeque = "0.4"
-flexi_logger = "0.22"
+flexi_logger = "0.24.2"
 lazy_static = "1.4"
 log = "0.4"
 unicode-width = "0.1"


### PR DESCRIPTION
Hi. Now it is possible to write like this, so it became kinda flexible.
```Rust
    Logger::try_with_env_or_str("info")
        .expect("Could not create Logger from environment :(")
        .filter(Box::new(MineOnly))
        .format(my_detailed_format)
        .format_for_writer(my_detailed_format)
        .log_to_file_and_writer(
            flexi_logger::FileSpec::default()
                .directory("logs")
                .suppress_timestamp(),
            cursive_flexi_logger_view::cursive_flexi_logger(&siv)
                .with_format(vec![DATETIME, LEVEL, FileLine, MESSAGE]) //These two lines are optional
                .with_time_format("%R") //without it all intended to work like before
        )
        .start()
        .expect("failed to initialize logger!");
```